### PR TITLE
Mode support: man/woman

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -171,6 +171,14 @@
   (elixir-atom-face                          (:foreground darktooth-lightblue4))
   (elixir-attribute-face                     (:foreground darktooth-burlywood4))
 
+  ;; MODE SUPPORT: man
+  (Man-overstrike                            (:foreground darktooth-bright_red :bold t))
+  (Man-underline                             (:foreground darktooth-bright_green :bold t))
+
+  ;; MODE SUPPORT: woman
+  (woman-bold                               (:foreground darktooth-bright_red :bold t))
+  (woman-italic                             (:foreground darktooth-bright_green :bold t))
+
   ;; MODE SUPPORT: whitespace-mode
   (whitespace-space                          (:foreground darktooth-dark4 :background darktooth-dark0))
   (whitespace-hspace                         (:foreground darktooth-dark4 :background darktooth-dark0))

--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -4,7 +4,7 @@
 
 ;; Authors: Jason Milkins <jasonm23@gmail.com>
 ;; URL: http://github.com/emacsfodder/emacs-theme-darktooth
-;; Version: 0.3.0
+;; Version: 0.3.1
 ;; Package-Requires: ((autothemer "0.2"))
 
 ;;; Commentary:


### PR DESCRIPTION
Adds colors to man/woman commands. Basically makes keywords stand out more, as with colorized man in a terminal. Pretty minor and preference based (the colors could be changed) but I think it's an improvement over the defaults.

Screenshots:

Man
<img width="690" alt="screen shot 2016-12-23 at 03 50 22" src="https://cloud.githubusercontent.com/assets/9020453/21450241/fc171202-c8c2-11e6-926b-ca5dbb32e4c9.png">

Woman
<img width="690" alt="screen shot 2016-12-23 at 03 50 33" src="https://cloud.githubusercontent.com/assets/9020453/21450245/01f41a08-c8c3-11e6-8d4a-bf441704c20c.png">

