### PR TITLE
Mode support: emacs-which-key

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -4,7 +4,7 @@
 
 ;; Authors: Jason Milkins <jasonm23@gmail.com>
 ;; URL: http://github.com/emacsfodder/emacs-theme-darktooth
-;; Version: 0.3.3
+;; Version: 0.3.4
 ;; Package-Requires: ((autothemer "0.2"))
 
 ;;; Commentary:

--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -165,6 +165,9 @@
   (font-lock-type-face                               (:foreground darktooth-lightblue4))
   (font-lock-warning-face                            (:foreground darktooth-neutral_red :bold t))
 
+  ;; MODE SUPPORT: which-key
+  (which-key-key-face                        (:inherit 'font-lock-variable-name-face))
+
   ;; MODE SUPPORT: elixir-mode
   (elixir-atom-face                          (:foreground darktooth-lightblue4))
   (elixir-attribute-face                     (:foreground darktooth-burlywood4))


### PR DESCRIPTION
I'm still not entirely sure how I feel about this one, but I thought the which-key colors were a bit too monotone for the theme. I tried other colors, but the light blue of the variable-name-face was the only one I found subtle enough to add pop but not be jarring.


**EDIT:** Screenshot:
<img width="525" alt="screen shot 2017-02-16 at 19 51 13" src="https://cloud.githubusercontent.com/assets/9020453/23048032/56be99ca-f481-11e6-9436-eddacbed29e0.png">
