### PR TITLE
Explicitly set magit-section-highlight to grey20 background

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -586,6 +586,7 @@
   (git-gutter-fr+-modified                   (:inherit 'git-gutter+-modified))
 
   ;; MODE SUPPORT: magit
+  (magit-section-highlight                   (:background darktooth-black))
   (magit-branch                              (:foreground darktooth-turquoise4 :background nil))
   (magit-branch-local                        (:foreground darktooth-turquoise4 :background nil))
   (magit-branch-remote                       (:foreground darktooth-aquamarine4 :background nil))

--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -586,7 +586,7 @@
   (git-gutter-fr+-modified                   (:inherit 'git-gutter+-modified))
 
   ;; MODE SUPPORT: magit
-  (magit-section-highlight                   (:background darktooth-black))
+  (magit-section-highlight                   (:background darktooth-dark0_soft))
   (magit-branch                              (:foreground darktooth-turquoise4 :background nil))
   (magit-branch-local                        (:foreground darktooth-turquoise4 :background nil))
   (magit-branch-remote                       (:foreground darktooth-aquamarine4 :background nil))


### PR DESCRIPTION
Magit uses magit-section-highlight for the current section. That was unreadable.
This commits makes that face use just a black background.