### PR TITLE
Change font for org-date to have more contrast

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -332,7 +332,7 @@
   (org-agenda-structure                      (:inherit 'font-lock-comment-face))
   (org-archived                              (:foreground darktooth-light0 :weight 'bold))
   (org-checkbox                              (:foreground darktooth-light2 :background darktooth-dark0 :box (:line-width 1 :style 'released-button)))
-  (org-date                                  (:foreground darktooth-neutral_aqua :underline t))
+  (org-date                                  (:foreground darktooth-faded_aqua :underline t))
   (org-deadline-announce                     (:foreground darktooth-faded_red))
   (org-document-info-keyword                 (:foreground darktooth-light2))
   (org-document-info                         (:foreground darktooth-identifiers-7))

--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -332,7 +332,7 @@
   (org-agenda-structure                      (:inherit 'font-lock-comment-face))
   (org-archived                              (:foreground darktooth-light0 :weight 'bold))
   (org-checkbox                              (:foreground darktooth-light2 :background darktooth-dark0 :box (:line-width 1 :style 'released-button)))
-  (org-date                                  (:foreground darktooth-faded_blue :underline t))
+  (org-date                                  (:foreground darktooth-neutral_aqua :underline t))
   (org-deadline-announce                     (:foreground darktooth-faded_red))
   (org-document-info-keyword                 (:foreground darktooth-light2))
   (org-document-info                         (:foreground darktooth-identifiers-7))


### PR DESCRIPTION
The current value for org-date is darktooth-faded_blue which has
very little contrast. My expectation is that dates stand out
because they are important. All the other variants of blue can not
be used (either to dark or conflict with level 3), that's why I
suggest an aqua variant here: darktooth-neutral_aqua.

## Emacs 25.1 before the change

![org-date-e251-pre](https://cloud.githubusercontent.com/assets/972373/24403866/1f186584-13bf-11e7-925f-b59823d7e5b0.png)

## Emacs 25.1 after the change

![org-date-e251-post](https://cloud.githubusercontent.com/assets/972373/24403882/33de984e-13bf-11e7-9471-4a8d75de61df.png)

