### PR TITLE
Added support for which-func

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -168,6 +168,9 @@
   ;; MODE SUPPORT: which-key
   (which-key-key-face                        (:inherit 'font-lock-variable-name-face))
 
+  ;; MODE SUPPORT: which-func
+  (which-func                                (:inherit 'font-lock-function-name-face))
+
   ;; MODE SUPPORT: elixir-mode
   (elixir-atom-face                          (:foreground darktooth-lightblue4))
   (elixir-attribute-face                     (:foreground darktooth-burlywood4))


### PR DESCRIPTION
* which-func is a minor mode which shows the func at point in the
  modeline.
* The face definition is pretty complex and in many cases inherits
  from font-lock-function-name-face. On some displays it just becomes
  some shade of blue.
* The blue does not fit the looks of darktooth.
* This commits adds explicit support for which-func by inheriting from
  font-lock-function-name-face.


## Emacs 25.1 pre change

![which-func-e251-pre](https://cloud.githubusercontent.com/assets/972373/24408140/25d38a6c-13cd-11e7-888b-0e146cc67ab9.png)

## Emacs 25.1 post change

![which-func-e251-post](https://cloud.githubusercontent.com/assets/972373/24408160/31e50740-13cd-11e7-8f3e-cb0ba2bb0c63.png)
