### PR TITLE
Mode support: Web-mode

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -703,7 +703,14 @@
   (message-header-xheader                    (:foreground darktooth-faded_cyan ))
   (message-separator                         (:foreground darktooth-faded_cyan ))
   (message-cited-text                        (:foreground darktooth-light3 ))
-  (message-mml                               (:foreground darktooth-faded_aqua )))
+  (message-mml                               (:foreground darktooth-faded_aqua ))
+
+  ;; MODE SUPPORT: Web
+  (web-mode-doctype-face                     (:foreground darktooth-light2 :weight 'bold))
+  (web-mode-html-attr-name-face              (:inherit 'font-lock-variable-name-face))
+  (web-mode-html-attr-equal-face             (:inherit 'default))
+  (web-mode-html-tag-face                    (:foreground darktooth-light3))
+  (web-mode-html-tag-bracket-face            (:inherit 'default)))
 
  (defface darktooth-modeline-one-active
    `((t


### PR DESCRIPTION
This is mostly for consistency with `html-mode`, not necessarily what I think are optimal colors. Screenshot for comparison below, `web-mode` on left, `html-mode` on right. You'll notice tags are a little lighter, since in `html-mode` they inherit from `font-lock-function-name-face` but `web-mode` already has things that inherit from that face (function calls within `<script>`). Additionally, I made the doctype face a little different since it made no sense to me that it would inherit from `font-lock-string-face`. I barely ever edit html, so this is just what I gathered from the few documents I was working on at the moment.

Before:
![2017-04-06_00 08 05](https://cloud.githubusercontent.com/assets/9020453/24737496/26b63966-1a5d-11e7-809e-b8e1ef5081df.png)

After:
![2017-04-06_00 01 08](https://cloud.githubusercontent.com/assets/9020453/24737400/4b9b8642-1a5c-11e7-993c-80683549c628.png)
