### PR TITLE
Add diff refine colors

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -302,7 +302,9 @@
   ;; MODE SUPPORT: diff
   (diff-changed                              (:foreground darktooth-light1 :background nil))
   (diff-added                                (:foreground darktooth-neutral_green :background nil))
+  (diff-refine-added                         (:foreground darktooth-bright_green :background darktooth-muted_green))
   (diff-removed                              (:foreground darktooth-neutral_red :background nil))
+  (diff-refine-removed                       (:foreground darktooth-bright_red :background darktooth-muted_red))
 
   ;; MODE SUPPORT: diff-indicator
   (diff-indicator-changed                    (:inherit 'diff-changed))


### PR DESCRIPTION
Add `diff-refine-added` and `diff-refine-removed` colors.
Quite useful when using magit with hunk refinement.
Without those colors, the refinement background and foreground colors were nearly the same, making them difficult to read.

Screenshot of magit with hunk refinement:
![screenshot_20170715_163706](https://user-images.githubusercontent.com/6860164/28240168-7a31e752-697c-11e7-861b-8bf244075710.png)
