### PR TITLE
Add helm swoop

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -720,7 +720,12 @@
   (web-mode-html-attr-name-face              (:inherit 'font-lock-variable-name-face))
   (web-mode-html-attr-equal-face             (:inherit 'default))
   (web-mode-html-tag-face                    (:foreground darktooth-light3))
-  (web-mode-html-tag-bracket-face            (:inherit 'default)))
+  (web-mode-html-tag-bracket-face            (:inherit 'default))
+
+  ;; MODE SUPPORT: helm-swoop
+  (helm-swoop-target-word-face               (:foreground darktooth-light0 :background darktooth-faded_aqua))
+  (helm-swoop-target-line-block-face         (:foreground darktooth-light0_hard :background darktooth-faded_blue))
+  (helm-swoop-target-line-face               (:foreground darktooth-light0_hard :background darktooth-faded_blue)))
 
  (defface darktooth-modeline-one-active
    `((t

--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -722,10 +722,18 @@
   (web-mode-html-tag-face                    (:foreground darktooth-light3))
   (web-mode-html-tag-bracket-face            (:inherit 'default))
 
+  ;; MODE SUPPORT: swoop
+  (swoop-face-target-line                    (:foreground darktooth-light0_hard :background darktooth-faded_blue))
+  (swoop-face-target-words                   (:foreground darktooth-light0 :background darktooth-faded_aqua))
+  (swoop-face-line-buffer-name               (:foreground darktooth-light2 :background darktooth-dark1))
+  (swoop-face-header-format-line             (:foreground darktooth-white :background darktooth-muted_blue :height 1.3 :weight 'bold))
+  (swoop-face-line-number                    (:foreground darktooth-neutral_orange))
+
   ;; MODE SUPPORT: helm-swoop
   (helm-swoop-target-word-face               (:foreground darktooth-light0 :background darktooth-faded_aqua))
   (helm-swoop-target-line-block-face         (:foreground darktooth-light0_hard :background darktooth-faded_blue))
-  (helm-swoop-target-line-face               (:foreground darktooth-light0_hard :background darktooth-faded_blue)))
+  (helm-swoop-target-line-face               (:foreground darktooth-light0_hard :background darktooth-faded_blue))
+  (helm-swoop-line-number-face               (:foreground darktooth-neutral_orange)))
 
  (defface darktooth-modeline-one-active
    `((t


### PR DESCRIPTION
Add support for `swoop` and `helm-swoop` (that by default use flashy yellow and purple colours).
I used colours from i-search and helm.

 # Swoop
Before:
![swoop-before](https://user-images.githubusercontent.com/6860164/28240408-c4f61132-6981-11e7-9c8c-0bef9404b84f.png)

After:
![swoop-after](https://user-images.githubusercontent.com/6860164/28240410-c78a2834-6981-11e7-879d-cb804bbad134.png)

# Helm-swoop
Before:
![helm-swoop-before](https://user-images.githubusercontent.com/6860164/28240412-ce9e4952-6981-11e7-8a73-f53654689178.png)

After:
![helm-swoop-after](https://user-images.githubusercontent.com/6860164/28240413-d15bda7e-6981-11e7-94cd-c0dd7329d68a.png)
