### PR TITLE
Add eldoc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ M-x package-install darktooth-theme
 - diff-indicator
 - dired+
 - el-search
+- eldoc
 - elfeed
 - elixir-mode
 - elscreen

--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -755,7 +755,11 @@
   (helm-swoop-target-word-face               (:foreground darktooth-light0 :background darktooth-faded_aqua))
   (helm-swoop-target-line-block-face         (:foreground darktooth-light0_hard :background darktooth-faded_blue))
   (helm-swoop-target-line-face               (:foreground darktooth-light0_hard :background darktooth-faded_blue))
-  (helm-swoop-line-number-face               (:foreground darktooth-neutral_orange)))
+  (helm-swoop-line-number-face               (:foreground darktooth-neutral_orange))
+
+  ;; MODE SUPPORT: eldoc
+  (eldoc-highlight-function-argument         (:foreground darktooth-aquamarine4 :weight 'bold)))
+
 
  (defface darktooth-modeline-one-active
    `((t


### PR DESCRIPTION
By default, eldoc just put the current argument in bold, which I found it not very visible.
This is especially true when arguments are lower case (not in elisp then, but in python for example).

This PR customize `eldoc-highlight-function-argument` face to add a bit of colors.

- Before:
![eldoc1](https://user-images.githubusercontent.com/6860164/43034774-dbf9057e-8cda-11e8-94c8-0a716019dd73.png)
- After:
![eldoc2](https://user-images.githubusercontent.com/6860164/43034775-dc0e0aa0-8cda-11e8-83ef-6c9d7cd0811f.png)
