### PR TITLE
support pdf-view-midnight-minor-mode

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -867,7 +867,8 @@
                                                         ,darktooth-neutral_blue
                                                         ,darktooth-neutral_purple
                                                         ,darktooth-neutral_cyan
-                                                        ,darktooth-light1])))
+                                                        ,darktooth-light1])
+			     `(pdf-view-midnight-colors '(,darktooth-light0 . ,darktooth-dark0))))
 
 (defun darktooth-modeline-one ()
   "Optional modeline style one for darktooth."


### PR DESCRIPTION
The `pdf-tools` package has a `pdf-view-midnight-minor-mode` with bright text on dark background. Using `darktooth` colors makes it look nicer.
The screenshot is here, however, other colors may be more beautiful.
![pdf-emacs-theme-darktooth](https://user-images.githubusercontent.com/10540480/46148350-734d5480-c29a-11e8-902f-b5179c54b96a.png)
