### PR TITLE
Added missing smerge faces

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -590,12 +590,13 @@
   (ivy-remote                                (:foreground darktooth-neutral_blue))
 
   ;; MODE SUPPORT: smerge
-  ;; TODO: smerge-base smerge-refined-changed
-  (smerge-mine                               (:background darktooth-mid_purple))
-  (smerge-other                              (:background darktooth-mid_blue))
+  (smerge-upper                              (:background darktooth-mid_purple))
+  (smerge-lower                              (:background darktooth-mid_blue))
+  (smerge-base                               (:background darktooth-dark_yellow))
   (smerge-markers                            (:background darktooth-dark0_soft))
   (smerge-refined-added                      (:background darktooth-dark_green))
   (smerge-refined-removed                    (:background darktooth-dark_red))
+  (smerge-refine-changed                     (:background nil :foreground nil))
 
   ;; MODE SUPPORT: git-gutter
   (git-gutter:added                         (:foreground darktooth-faded_green :background darktooth-muted_green ))


### PR DESCRIPTION
- Add the missing smerge face, notably `smerge-base` face, that is by default an annoyingly bright yellow.
- Update Smerge face names (`smerge-other`, `smerge-mine`, ... are now obsolete)
