### PR TITLE
Fix 'error/warning' colors in 'compile-log' buffer

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -154,9 +154,9 @@
   ;; compilation messages (also used by several other modes)
   (compilation-info                          (:foreground darktooth-neutral_green))
   (compilation-mode-line-fail                (:foreground darktooth-neutral_red))
-  (error                                     (:foreground darktooth-bright_orange :bold t))
+  (error                                     (:foreground darktooth-bright_red :bold t))
   (success                                   (:foreground darktooth-neutral_green :bold t))
-  (warning                                   (:foreground darktooth-bright_red :bold t))
+  (warning                                   (:foreground darktooth-bright_yellow :bold t))
 
   ;; Built-in syntax
   (font-lock-builtin-face                            (:foreground darktooth-bright_orange))


### PR DESCRIPTION
Make 'compile-log' colors consistent with 'flycheck' colors.
1. 'flycheck' colors:
![flycheck-error-warning-colors](https://user-images.githubusercontent.com/6495837/56005457-187cc700-5cd9-11e9-8a92-71f6e341b305.png)
2. 'compile-log' colors before fix:
![compile-log-error-warning-colors-before-fix](https://user-images.githubusercontent.com/6495837/56005474-3b0ee000-5cd9-11e9-84e1-2c6a0adc02e4.png)
3. 'compile-log' colors after fix:
![compile-log-error-warning-colors-after-fix](https://user-images.githubusercontent.com/6495837/56005476-3fd39400-5cd9-11e9-9940-241d8b6ad8db.png)
