### PR TITLE
Make diff-mode look like magit

### DIFF
--- a/darktooth-theme.el
+++ b/darktooth-theme.el
@@ -323,10 +323,14 @@
 
   ;; MODE SUPPORT: diff
   (diff-changed                              (:foreground darktooth-light1 :background nil))
-  (diff-added                                (:foreground darktooth-neutral_green :background nil))
+  (diff-added                                (:foreground darktooth-bright_green :background darktooth-mid_green))
   (diff-refine-added                         (:foreground darktooth-bright_green :background darktooth-muted_green))
-  (diff-removed                              (:foreground darktooth-neutral_red :background nil))
+  (diff-removed                              (:foreground darktooth-bright_red :background darktooth-mid_red))
   (diff-refine-removed                       (:foreground darktooth-bright_red :background darktooth-muted_red))
+  (diff-file-header                          (:weight 'bold :inherit 'default :extend t))
+  (diff-hunk-header                          (:foreground darktooth-light2 :background darktooth-dark2 :extend t))
+  (diff-header                               (:weight 'bold :inherit 'default :extend t))
+  (diff-context                              (:foreground darktooth-dark3 :background nil))
 
   ;; MODE SUPPORT: diff-indicator
   (diff-indicator-changed                    (:inherit 'diff-changed))


### PR DESCRIPTION
Add a few faces to make diff-mode look like magit.

Before:
![1601825989](https://user-images.githubusercontent.com/6860164/95019953-a0425800-0668-11eb-8548-87bbe0d7b355.png)

After:
![1601825572](https://user-images.githubusercontent.com/6860164/95019827-dfbc7480-0667-11eb-9efb-0469526777f5.png)
